### PR TITLE
[refactor] unic.go의 Move, DirMove 함수가 로컬 드라이브 cache 파일의 이름도 수정하도록 수정

### DIFF
--- a/backend/unic/unic.go
+++ b/backend/unic/unic.go
@@ -710,6 +710,22 @@ func (f *Fs) Move(ctx context.Context, src fs.Object, remote string) (fs.Object,
 		return nil, err
 	}
 
+	// Rename local cache file
+	oldLocalPath, err1 := f.MakeOSDownloadPath(srcPath)
+	newLocalPath, err2 := f.MakeOSDownloadPath(remote)
+	if err1 == nil && err2 == nil {
+		if _, err := os.Stat(oldLocalPath); err == nil {
+			// Ensure the destination directory exists
+			os.MkdirAll(filepath.Dir(newLocalPath), 0755)
+			// Rename the local cache
+			if err := os.Rename(oldLocalPath, newLocalPath); err != nil {
+				fmt.Printf("UNIC: Move: failed to rename local cache file from %s to %s: %v\n", oldLocalPath, newLocalPath, err)
+			} else {
+				fmt.Printf("UNIC: Move: successfully renamed local cache file from %s to %s\n", oldLocalPath, newLocalPath)
+			}
+		}
+	}
+
 	return f.newObject(ctx, remote, movedNode)
 }
 
@@ -766,6 +782,21 @@ func (f *Fs) DirMove(ctx context.Context, src fs.Fs, srcRemote, dstRemote string
 	if err := os.Rename(tempPath, entrytable_path); err != nil {
 		os.Remove(tempPath)
 		return err
+	}
+
+	// Rename local cache directory
+	oldLocalDir, err1 := f.MakeOSDownloadPath(srcRemote)
+	newLocalDir, err2 := f.MakeOSDownloadPath(dstRemote)
+	if err1 == nil && err2 == nil {
+		if _, err := os.Stat(oldLocalDir); err == nil {
+			// Ensure the destination directory exists
+			os.MkdirAll(filepath.Dir(newLocalDir), 0755)
+			if err := os.Rename(oldLocalDir, newLocalDir); err != nil {
+				fmt.Printf("UNIC: DirMove: failed to rename local cache dir from %s to %s: %v\n", oldLocalDir, newLocalDir, err)
+			} else {
+				fmt.Printf("UNIC: DirMove: successfully renamed local cache dir from %s to %s\n", oldLocalDir, newLocalDir)
+			}
+		}
 	}
 
 	return nil

--- a/vfs/file.go
+++ b/vfs/file.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -286,6 +287,7 @@ func (f *File) rename(ctx context.Context, destDir *Dir, newName string) error {
 				fs.Infof(f.Path(), "File.Rename failed in Cache: %v", err)
 			}
 		}
+
 		// Update the node with the new details
 		fs.Debugf(f.Path(), "Updating file with %v %p", newObject, f)
 		// f.rename(destDir, newObject)
@@ -307,6 +309,23 @@ func (f *File) rename(ctx context.Context, destDir *Dir, newName string) error {
 	f.leaf = newName
 	writing := f._writingInProgress()
 	f.mu.Unlock()
+
+	// For UNIC backend, immediately rename local cache file if it exists
+	// This happens synchronously even if the backend Rename is deferred via pendingRenameFun
+	if unicFs, ok := destDir.Fs().(*unic.Fs); ok {
+		oldLocalPath, err1 := unicFs.MakeOSDownloadPath(oldPath)
+		newLocalPath, err2 := unicFs.MakeOSDownloadPath(path.Join(dPath, newCacheName))
+		if err1 == nil && err2 == nil {
+			if _, err := os.Stat(oldLocalPath); err == nil {
+				os.MkdirAll(filepath.Dir(newLocalPath), 0755)
+				if err := os.Rename(oldLocalPath, newLocalPath); err != nil {
+					fs.Errorf(f.Path(), "UNIC: File.rename failed to immediately rename local cache file: %v", err)
+				} else {
+					fs.Infof(f.Path(), "UNIC: File.rename successfully renamed local cache file from %s to %s", oldLocalPath, newLocalPath)
+				}
+			}
+		}
+	}
 
 	// Delay the rename if not using RW caching. For the minimal case we
 	// need to look in the cache to see if caching is in use.

--- a/vfs/unichandle.go
+++ b/vfs/unichandle.go
@@ -309,7 +309,6 @@ func (fh *UnicFileHandle) close() (err error) {
 	if fh.isDirty {
 		// 필요한 변수들을 백그라운드 고루틴으로 넘기기 위해 변수에 캡쳐
 		remotePath := fh.remote
-		localPath := fh.localPath
 		vfsFile := fh.file
 		unicFs := fh.file.Fs().(*unic.Fs)
 
@@ -372,18 +371,23 @@ func (fh *UnicFileHandle) close() (err error) {
 			vfsFile.cancelUpload = nil
 			vfsFile.mu.Unlock() // 데드락 방지! Path() 호출 전 무조건 언락해야 합니다.
 
-			if _, err := os.Stat(localPath); os.IsNotExist(err) {
-				fmt.Printf("[%s] unichandle: async upload skipped (file deleted)\n", remotePath)
+			// 에디터의 rename 동작으로 인해 현재 파일 이름이 바뀌었을 수 있으므로 VFS File 객체의 최신 Path() 확인
+			currentRemotePath := vfsFile.Path()
+			currentLocalPath, errPath := unicFs.MakeOSDownloadPath(currentRemotePath)
+			if errPath != nil {
+				fs.Errorf(currentRemotePath, "async upload failed to get local path: %v", errPath)
 				return
 			}
 
-			// 에디터의 rename 동작으로 인해 현재 파일 이름이 바뀌었을 수 있으므로 VFS File 객체의 최신 Path() 확인
-			currentRemotePath := vfsFile.Path()
+			if _, err := os.Stat(currentLocalPath); os.IsNotExist(err) {
+				fmt.Printf("[%s] unichandle: async upload skipped (file deleted/not found at %s)\n", currentRemotePath, currentLocalPath)
+				return
+			}
 
 			fmt.Printf("[%s] unichandle: async upload started as [%s]\n", remotePath, currentRemotePath)
 
 			// Put_ 을 위해 파일을 새로 엽니다.
-			uploadFile, err := os.Open(localPath)
+			uploadFile, err := os.Open(currentLocalPath)
 			if err != nil {
 				fs.Errorf(remotePath, "async upload failed to re-open local cache: %v", err)
 				return


### PR DESCRIPTION
issue: https://github.com/MCNL-Cloud-Aggregator/UNIC_Rclone/issues/90